### PR TITLE
Allow image to be extracted to temp directory

### DIFF
--- a/tools/archive-debian
+++ b/tools/archive-debian
@@ -5,8 +5,7 @@
 IMAGE=$1
 OUTDIR=$2
 
-#IMAGETMP=$(mktemp -d -t image-XXXXXXX)
-IMAGETMP=image-temp
+IMAGETMP=$(mktemp -d -t image-XXXXXXX)
 mkdir -p $IMAGETMP
 tar -zxf $IMAGE -C $IMAGETMP
 
@@ -14,7 +13,7 @@ tar -zxf $IMAGE -C $IMAGETMP
 #INITRD=$(ls -al $IMAGETMP/boot/initramfs* | awk {'print $9'} | sort -V | grep -v rescue | head -1)
 KERNEL=$(ls -al $IMAGETMP/boot/vmlinuz-* | awk {'print $9'} | sort -V | tail -1)
 INITRD=$(ls -al $IMAGETMP/boot/initrd* | awk {'print $9'} | sort -V | tail -1)
-KERNELVER=$(echo $KERNEL | sed "s/$IMAGETMP\/boot\/vmlinuz-//g")
+KERNELVER=$(echo $KERNEL | sed "s:$IMAGETMP/boot/vmlinuz-::g")
 
 echo "Kernel file: $KERNEL"
 echo "Initrd file: $INITRD"


### PR DESCRIPTION
From the original commented line, it seems the intent had been to extract the image to the temp directory instead of the working directory but encountered issues with `sed` misinterpreting the un-escaped slashes in the absolute path returned by `mktemp`. By using an alternate sed delimiter (the colon) there should be no characters to escape in the path returned from `mktemp`.

Strictly there is likely a safer way to fix this without using `sed` at all but this is the least-code-touched solution.